### PR TITLE
Added queue length to GenServer state to avoid O(N)

### DIFF
--- a/lib/off_broadway_memory/buffer.ex
+++ b/lib/off_broadway_memory/buffer.ex
@@ -21,32 +21,32 @@ defmodule OffBroadwayMemory.Buffer do
   Push messages to the buffer.
   """
   @spec push(GenServer.server(), list(any()) | any()) :: :ok
-  def push(pid, messages) do
-    GenServer.call(pid, {:push, messages})
+  def push(server, messages) do
+    GenServer.call(server, {:push, messages})
   end
 
   @doc """
   Pop messages from the buffer.
   """
   @spec pop(GenServer.server(), non_neg_integer()) :: list(any())
-  def pop(pid, count \\ 1) do
-    GenServer.call(pid, {:pop, count})
+  def pop(server, count \\ 1) do
+    GenServer.call(server, {:pop, count})
   end
 
   @doc """
   Clear all messages from the buffer.
   """
   @spec clear(GenServer.server()) :: :ok
-  def clear(pid) do
-    GenServer.call(pid, :clear)
+  def clear(server) do
+    GenServer.call(server, :clear)
   end
 
   @doc """
   Get the length of the buffer.
   """
   @spec length(GenServer.server()) :: non_neg_integer()
-  def length(pid) do
-    GenServer.call(pid, :length)
+  def length(server) do
+    GenServer.call(server, :length)
   end
 
   @impl true

--- a/lib/off_broadway_memory/buffer.ex
+++ b/lib/off_broadway_memory/buffer.ex
@@ -20,7 +20,7 @@ defmodule OffBroadwayMemory.Buffer do
   @doc """
   Push messages to the buffer.
   """
-  @spec push(pid(), list(any()) | any()) :: :ok
+  @spec push(GenServer.server(), list(any()) | any()) :: :ok
   def push(pid, messages) do
     GenServer.call(pid, {:push, messages})
   end
@@ -28,7 +28,7 @@ defmodule OffBroadwayMemory.Buffer do
   @doc """
   Pop messages from the buffer.
   """
-  @spec pop(pid(), non_neg_integer()) :: list(any())
+  @spec pop(GenServer.server(), non_neg_integer()) :: list(any())
   def pop(pid, count \\ 1) do
     GenServer.call(pid, {:pop, count})
   end
@@ -36,7 +36,7 @@ defmodule OffBroadwayMemory.Buffer do
   @doc """
   Clear all messages from the buffer.
   """
-  @spec clear(pid()) :: :ok
+  @spec clear(GenServer.server()) :: :ok
   def clear(pid) do
     GenServer.call(pid, :clear)
   end
@@ -44,7 +44,7 @@ defmodule OffBroadwayMemory.Buffer do
   @doc """
   Get the length of the buffer.
   """
-  @spec length(pid()) :: non_neg_integer()
+  @spec length(GenServer.server()) :: non_neg_integer()
   def length(pid) do
     GenServer.call(pid, :length)
   end


### PR DESCRIPTION
First of all thanks for the library!

Opening up this PR to add the length of the queue to the GenServer state since per the Erlang documentation `:queue.len/1` has a running time of O(N):
<img width="852" alt="image" src="https://github.com/elliotekj/off_broadway_memory/assets/4753634/da3eed91-a7e3-479f-b44e-95b6dea71ef4">

By having the queue length in the GenServer state, every time a pop request comes in you no longer need to traverse the entire queue and you can lean on the state of the GenServer instead.