### PR TITLE
fix: GenServer.start_link options

### DIFF
--- a/lib/off_broadway_memory/buffer.ex
+++ b/lib/off_broadway_memory/buffer.ex
@@ -9,7 +9,7 @@ defmodule OffBroadwayMemory.Buffer do
 
   @doc false
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, opts)
+    GenServer.start_link(__MODULE__, nil, opts)
   end
 
   @impl true

--- a/test/off_broadway_memory/buffer_test.exs
+++ b/test/off_broadway_memory/buffer_test.exs
@@ -8,6 +8,14 @@ defmodule OffBroadwayMemory.BufferTest do
     {:ok, %{buffer_pid: pid}}
   end
 
+  describe "start_link/1" do
+    test "uses options" do
+      Buffer.start_link(name: :buffer)
+      assert :ok == Buffer.push(:buffer, "test")
+      assert ["test"] == Buffer.pop(:buffer)
+    end
+  end
+
   describe "push/2" do
     test "pushes a message", %{buffer_pid: buffer_pid} do
       assert :ok == Buffer.push(buffer_pid, "test")


### PR DESCRIPTION
Hi, I was trying to register the buffer with a name and found that `OffBroadwayMemory.Buffer.start_link/1` doesn't actually use the options passed in because `GenServer.start_link/3` also takes an arg for the initial state.