### PR TITLE
Fix message acknowledgment configuration to handle 'on_failure' option correctly

### DIFF
--- a/lib/off_broadway_memory/producer.ex
+++ b/lib/off_broadway_memory/producer.ex
@@ -192,7 +192,7 @@ defmodule OffBroadwayMemory.Producer do
 
     case message_ack_options[:on_failure] do
       nil -> default
-      ack? -> ack?
+      ack? -> ack? == :requeue
     end
   end
 end


### PR DESCRIPTION
When user set configure ack for message.
Ex:
```
  def handle_failed(messages, _context) do
    messages
    |> Enum.map(fn msg ->
      Message.configure_ack(msg, on_failure: :discard)
    end)
  end
```
Filter does not work as expected because the Enum.filter always return `true`.

Fix: Using message_ack_options[:on_failure] by compare with :requeue atom.